### PR TITLE
Add reverse string and %p format specifiers

### DIFF
--- a/get_specifier.c
+++ b/get_specifier.c
@@ -24,6 +24,8 @@ int (*get_specifier(const char *c))(va_list args, char *buffer, int size)
 		{"x", hex_print},
 		{"X", hex_print},
 		{"S", s_print},
+		{"r", reverse_str},
+		{"p", address_print},
 		{NULL, NULL}
 	};
 	int i = 0;

--- a/handlers.c
+++ b/handlers.c
@@ -16,6 +16,8 @@ int char_print(va_list args, char *buffer, int buffer_size)
 {
 	char c;
 
+	if (buffer == NULL)
+		return (0);
 	c = va_arg(args, int);
 	if (c == '\0')
 	{
@@ -44,7 +46,7 @@ int str_print(va_list args, char *buffer, int buffer_size)
 	const char *str;
 
 	str = va_arg(args, char *);
-	if (str == NULL)
+	if (str == NULL || buffer == NULL)
 		return (0);
 	while (*(str + str_length) != '\0')
 	{
@@ -71,6 +73,8 @@ int num_print(va_list args, char *buffer, int buffer_size)
 	char temp_arr[20] = ""; /* Temporary buffer to hold digits */
 	int i = 0;
 
+	if (buffer == NULL)
+		return (0);
 	num = va_arg(args, int);
 	if (num < 0)
 	{
@@ -119,6 +123,8 @@ int bin_print(va_list args, char *buffer, int buffer_size)
 			     */
 	int printed_digits = 0;
 
+	if (buffer == NULL)
+		return (0);
 	num = va_arg(args, int);
 	if (num == 0)
 	{

--- a/main.h
+++ b/main.h
@@ -2,6 +2,7 @@
 #define MAIN_H
 
 #include <stdarg.h>
+#include <stdint.h>
 
 int _putchar(char c);
 int _printf(const char *format, ...);
@@ -33,5 +34,9 @@ int unsigned_print(va_list args, char *buffer, int buffer_size);
 int oct_print(va_list args, char *buffer, int buffer_size);
 int hex_print(va_list args, char *buffer, int buffer_size);
 int s_print(va_list args, char *buffer, int buffer_size);
+int reverse_str(va_list args, char *buffer, int buffer_size);
+int address_print(va_list args, char *buffer, int buffer_size);
+int address_helper(uintptr_t num, char *buffer, int buffer_size);
+int hex_print_helper(int num, char *buffer, int buffer_size);
 
 #endif /* #ifndef MAIN_H */

--- a/my_printf.c
+++ b/my_printf.c
@@ -32,8 +32,8 @@ int _printf(const char *format, ...)
 		{
 			i++;
 			if (*(format + i) == 'c' || *(format + i) == 's' ||
-					*(format + i) == 'd' || *(format + i) == 'i' ||
-					*(format + i) == 'b' || *(format + i) == 'u' ||
+					*(format + i) == 'd' || *(format + i) == 'i' || *(format + i) == 'r' ||
+					*(format + i) == 'b' || *(format + i) == 'u' || *(format + i) == 'p' ||
 					*(format + i) == 'o' || *(format + i) == 'x' ||
 					*(format + i) == 'X' || *(format + i) == 'S')
 			{

--- a/p_handler.c
+++ b/p_handler.c
@@ -1,0 +1,86 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include "main.h"
+
+/**
+ * address_print - Prints the address of a variable
+ * @args: A variable of type va_list from which the argument is to be extracted
+ * @buffer: Pointer to a character array that will hold the characters
+ * to be printed
+ * @buffer_size: The current index of the buffer at the time of
+ * the function call
+ *
+ * Return: The number of characters printed
+ */
+int address_print(va_list args, char *buffer, int buffer_size)
+{
+	void *ptr = NULL;
+	uintptr_t address = 0;
+	int printed_chars = 0;
+
+	ptr = va_arg(args, void *);
+	if (ptr == NULL || buffer == NULL)
+		return (0);
+	address = (uintptr_t)ptr;
+	buffer[buffer_size++] = 0 + '0';
+	buffer[buffer_size++] = 'x';
+	printed_chars += 2;
+	printed_chars += address_helper(address, buffer, buffer_size);
+	return (printed_chars);
+}
+
+/**
+ * address_helper - Function that handles the delegated funcionality
+ * of converting a number to its hexadecimal equivalent
+ * @num: Number to be converted
+ * @buffer: Pointer to a character array that will hold the characters
+ * to be printed
+ * @buffer_size: The current index of the buffer at the time of
+ * the function call
+ *
+ * Return: The number of printed characters
+ */
+int address_helper(uintptr_t num, char *buffer, int buffer_size)
+{
+	char temp_arr[16];
+	int i = 0;
+	int n = 0;
+
+	if (buffer == NULL)
+		return (0);
+	if (num == 0)
+	{
+		buffer[buffer_size++] = 0 + '0';
+		return (1);
+	}
+	while (num)
+	{
+		n = num % 16;
+		if (n < 9)
+		{
+			temp_arr[i] = n + '0';
+		}
+		else
+		{
+			if (n == 10)
+				*(temp_arr + i) = 'a';
+			else if (n == 11)
+				*(temp_arr + i) = 'b';
+			else if (n == 12)
+				*(temp_arr + i) = 'c';
+			else if (n == 13)
+				*(temp_arr + i) = 'd';
+			else if (n == 14)
+				*(temp_arr + i) = 'e';
+			else if (n == 15)
+				*(temp_arr + i) = 'f';
+		}
+		i++;
+		num /= 16;
+	}
+	n = i;
+	while (i)
+		buffer[buffer_size++] = temp_arr[--i];
+	return (n);
+}

--- a/reverse_str.c
+++ b/reverse_str.c
@@ -1,0 +1,30 @@
+#include <stddef.h>
+#include <stdarg.h>
+#include "main.h"
+
+/**
+ * reverse_str - Prints the reversed string
+ * @args: A variable of type va_list that will be used to estract the variable
+ * @buffer: Pointer an array of characters that holds the characters
+ * to be printed
+ * @buffer_size: The current index of the buffer at the time of
+ * the function call
+ *
+ * Return: The number of characters printed
+ */
+int reverse_str(va_list args, char *buffer, int buffer_size)
+{
+	const char *str;
+	int str_length = 0;
+	int printed_chars = 0;
+
+	str = va_arg(args, char *);
+	if (str == NULL)
+		return (0);
+	while (*(str + str_length) != '\0')
+		str_length++;
+	printed_chars = str_length;
+	while (str_length)
+		buffer[buffer_size++] = str[--str_length];
+	return (printed_chars);
+}

--- a/s_handler.c
+++ b/s_handler.c
@@ -17,7 +17,7 @@ int s_print(va_list args, char *buffer, int buffer_size)
 	const char *str;
 
 	str = va_arg(args, char *);
-	if (str == NULL)
+	if (str == NULL || buffer == NULL)
 		return (0);
 	while (*(str + str_length) != '\0')
 	{

--- a/u_o_x_handlers.c
+++ b/u_o_x_handlers.c
@@ -21,6 +21,8 @@ int oct_print(va_list args, char *buffer, int buffer_size)
 			    * representation of the decimal number
 			    */
 
+	if (buffer == NULL)
+		return (0);
 	num = va_arg(args, int);
 	while (num)
 	{
@@ -48,10 +50,37 @@ int hex_print(va_list args, char *buffer, int buffer_size)
 {
 	int printed_chars = 0;
 	int num = 0;
-	int i = 0;
-	char temp_arr[8]; /* Temporary buffer */
 
+	if (buffer == NULL)
+		return (0);
 	num = va_arg(args, int);
+	if (num == 0)
+	{
+		buffer[buffer_size++] = 0 + '0';
+		return (1);
+	}
+	printed_chars += hex_print_helper(num, buffer, buffer_size);
+	return (printed_chars);
+}
+
+/**
+ * hex_print_helper - Function that handles work delegated from hex_print()
+ * @num: Number to be converted into its hexadecimal equivalent
+ * @buffer: Pointer to an array character that will hold the characters
+ * to be printed
+ * @buffer_size: The current index of the buffer at the time of the
+ * function call
+ *
+ * Return: The number of characters that will be printed
+ */
+int hex_print_helper(int num, char *buffer, int buffer_size)
+{
+	char temp_arr[16]; /* Temporary buffer */
+	int i = 0;
+	int printed_chars = 0;
+
+	if (buffer == NULL)
+		return (0);
 	while (num)
 	{
 		int n;
@@ -102,6 +131,8 @@ int unsigned_print(va_list args, char *buffer, int buffer_size)
 	int i = 0;
 	char temp_arr[32];
 
+	if (buffer == NULL)
+		return (0);
 	num = va_arg(args, int);
 	while (num)
 	{


### PR DESCRIPTION

### Changes being made
Two new files have been added to handle the %p format specifier and the custom %r specifier that reverses a given string.
p_handler.c contains the function that handles %p, while reverse_str.c contains the function that %r.
Some changes were also made to the functions in get_specifier.c,handlers.c, s_handler and u_o_x_handlers.c to include cases where the char *buffer has a NULL reference. These were made to try and correct checker errors.

### Context of the changes
Adding the reverse string (%r) and %p format specifiers.
Trying to make corrections for checker errors.

### Have you followed the collaboration guidelines?
- [x] I pulled all possible changes from upstream before adding changes
- [x] My files passed all betty styling and documentation guidelines
- [x] I've tested my program/source code
- [x] Proper commit messages

### Other context
None.
